### PR TITLE
fix: Remove need to for grouping semantic typography by theme; add pr…

### DIFF
--- a/bin/entities/SemanticToken/index.ts
+++ b/bin/entities/SemanticToken/index.ts
@@ -61,19 +61,8 @@ class SemanticToken extends Token {
         if (this.primitives === undefined) {
           throw Error(ErrorMakeColorTokensNoPrimitive);
         }
-        const typeByThemes: any = {};
         if (!frame.children) throw Error(ErrorMakeFontTokensNoFrame);
-        const themes = frame.children.reverse();
-        themes.forEach((f: Frame) => {
-          if (f.type === 'FRAME' && f.name.startsWith('theme/')) {
-            typeByThemes[f.name.substring(6)] = makeSemanticFontTokens(
-              f,
-              this.primitives,
-              camelizeTokenNames
-            );
-          }
-        });
-        return typeByThemes;
+        return makeSemanticFontTokens(frame, this.primitives, camelizeTokenNames);
       },
       semanticmobiletypography: () => {
         return makeSemanticFontTokens(frame, this.primitives, camelizeTokenNames);

--- a/bin/entities/Token/logic/makeSemanticFontTokens.ts
+++ b/bin/entities/Token/logic/makeSemanticFontTokens.ts
@@ -98,7 +98,7 @@ function makeSemFontToken(
   // Create line height token reference
   let heightsKey = getKeyByValue(
     lineHeights.file,
-    (STYLE.lineHeightPercentFontSize / 100).toString()
+    (STYLE.lineHeightPercentFontSize / 100).toPrecision(3).toString()
   );
   if (heightsKey !== undefined) {
     typography[NAME + 'LineHeight'] = `${lineHeights.name}.${heightsKey}`;

--- a/bin/frameworks/filesystem/getFileContentAndPath.ts
+++ b/bin/frameworks/filesystem/getFileContentAndPath.ts
@@ -166,12 +166,10 @@ const getSemanticTokenString = (file: string | ProcessedToken, name: string, for
     case 'semanticDesktopTypography':
     case 'semanticMobileTypography':
     case 'semanticTabletTypography':
-      importStatements.push("import { colors } from './colors';\n");
       importStatements.push("import { fontFamilies } from './fontFamilies';\n");
       importStatements.push("import { fontSizes } from './fontSizes';\n");
       importStatements.push("import { fontWeights } from './fontWeights';\n");
       importStatements.push("import { lineHeights } from './lineHeights';\n");
-      importStatements.push("import { letterSpacings } from './letterSpacings';\n");
       break;
   }
   output += `// ${MsgGeneratedFileWarning}\n\n`;

--- a/figmagicrc
+++ b/figmagicrc
@@ -9,6 +9,6 @@
   "outputFormatElements": "tsx",
   "outputFormatTokens": "ts",
   "spacingUnit": "rem",
-  "usePostscriptFontNames": true,
+  "usePostscriptFontNames": false,
   "debugMode": true
 }


### PR DESCRIPTION
In addition to PD-241, there's also minor cleanup and bug fixes in this commit. The big one was tracking down a precision issue and font family naming issue that was causing the semantic typography files to not find the corresponding line heights and family names. This is because we're taking the text element from figma and inspecting it for values (i.e., line height, font size, family, weight) and then using those values to look up the primitive token name. 

Apparently there's some minor variations in numeric precision when read back from the Figma API. Also, having the figmagicrc config usePostscriptFontNames=true means the fontFamilies token values use a longer (and more importantly, different) name than the STYLE.fontFamily property returns (makeSemanticFontTokens.ts line 87). Be sure to adjust local .figmagicrc values appropriately before running. 

- Remove need to for grouping semantic typography by theme; 
- Add precision to comparison of lineheight primitive token values in semantic typography generation so that small precision variations don't cause primitive tokens to not be found; 
- Remove unused color import statement in semantic typography files; 
- Change usePostscriptFontNames to be false in figmagicrc so that font families are represented with the overall family name